### PR TITLE
Add missing git feature to INSTALL.md plugin list

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, gpu-usage, ram-usage, network, network-bandwidth, weather, time
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, network, network-bandwidth, weather, time
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
 


### PR DESCRIPTION
As the title suggests, the git plugin is missing from the list on the Dracula website. This PR fixes that.