### PR TITLE
Show network bandwidth in gB/s and mB/s when required

### DIFF
--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -7,6 +7,11 @@ network_name=$(tmux show-option -gqv "@dracula-network-bandwidth")
 main() {
   while true
   do
+    output_download=""
+    output_upload=""
+    output_download_unit=""
+    output_upload_unit=""
+
     initial_download=$(cat /sys/class/net/$network_name/statistics/rx_bytes)
     initial_upload=$(cat /sys/class/net/$network_name/statistics/tx_bytes)
 
@@ -18,10 +23,29 @@ main() {
     total_download_bps=$(expr $final_download - $initial_download)
     total_upload_bps=$(expr $final_upload - $initial_upload)
 
-    total_download_kbps=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
-    total_upload_kbps=$(echo "$total_upload_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
+    if [ $total_download_bps -gt 1073741824 ]; then
+      output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/($2 * $2 * $2)}')
+      output_download_unit="gB/s"
+    elif [ $total_download_bps -gt 1048576 ]; then
+      output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/($2 * $2)}')
+      output_download_unit="mB/s"
+    else
+      output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
+      output_download_unit="kB/s"
+    fi
 
-    echo "↓ $total_download_kbps kB/s • ↑ $total_upload_kbps kB/s"
+    if [ $total_upload_bps -gt 1073741824 ]; then
+      output_upload=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/($2 * $2 * $2)}')
+      output_upload_unit="gB/s"
+    elif [ $total_upload_bps -gt 1048576 ]; then
+      output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%.2f \n", $1/($2 * $2)}')
+      output_upload_unit="mB/s"
+    else
+      output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
+      output_upload_unit="kB/s"
+    fi
+
+    echo "↓ $output_download $output_download_unit • ↑ $output_upload $output_upload_unit"
   done
 }
 main


### PR DESCRIPTION
This PR changes how network bandwidth is shown, by displaying transfer speeds over a gigabyte in gB/s, and over a megabyte in mB/s. Anything below a megabyte is shown in the current kB/s unit.

I'm aware this probably doesn't play nice with #113, so I'm fine with waiting for that to be merged first and then I'll fix the conflicts. This was just getting on my nerves so I figured I'd open a PR anyway :)

![Screenshot_20211010_044900](https://user-images.githubusercontent.com/4153572/136681079-be0182a0-4db2-4c32-94d2-51b3e6e16df1.png)

![image](https://user-images.githubusercontent.com/4153572/136681089-01aaf4a2-11c6-4517-b7e4-b5865d23c070.png)

