### PR TITLE
feat/fix/multi battery display

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -223,7 +223,6 @@ these settings will introduce the following icons:
 if you have no battery and would like the widget to hide in that case, set the following:
 
 ```bash
-set -g @dracula-battery-label false
 set -g @dracula-no-battery-label false
 ```
 

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -178,11 +178,10 @@ main()
   if [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
     echo "$no_bat_label"
   else
-    num_bats=$(wc -l <<< "$bat_perc")
-
     IFS=$'\n' read -rd '' -a percs <<<"$bat_perc"
     IFS=$'\n' read -rd '' -a stats <<<"$(get_battery_status)"
     IFS=$'\n' read -rd '' -a lbls <<<"$bat_label"
+    num_bats=${#percs[@]}
     show_bat_label=$(get_tmux_option "@dracula-show-battery-status" false)
     for ((i=0; i<num_bats; i++)); do
       if [[ i -gt 0 ]]; then


### PR DESCRIPTION
# support multiple batteries
upgrading the battery widget to display an arbitrary amount of detected batteries.  
## battery label
the battery label can be removed, set at just the leftmost end, or set for each battery individually.  
setting multiple battery labels requires separating them with newlines
```bash
# setting multiple labels
set -g @dracula-battery-label "1:\n2:"
# setting one label
set -g @dracula-battery-label "bat"
# setting no label
set -g @dracula-battery-label false
```
## battery divider
as soon as there is more than one battery, a divider can be set. with the following being the default setting.
```bash
set -g @dracula-battery-separator "; "
```
## nerdfont battery status
the battery status continues to be displayed as nerdfont glyph for each battery individually, as it was for one battery before.

tested under:
 - [x] linux (x86 with two batteries) with and without acpi
 - [ ] linux (x86 with one battery) with and without acpi
 - [ ] linux (x86 without battery) with and without acpi
 - [x] MacOS (apple silicon with one battery)