### PR TITLE
change spr.sh to display playback info instead of back button

### DIFF
--- a/scripts/spr.sh
+++ b/scripts/spr.sh
@@ -113,7 +113,7 @@ main() {
     sliceTrack "$full_track" "$MAX_LENGTH" > "$cache_file"
   fi
 
-  echo "$BACK_BUTTON"
+  cat "$cache_file"
 }
 
 main


### PR DESCRIPTION
Ran into a bug where all I saw on the powerline was "R", fixed it.