### PR TITLE
fix(scripts/cpu_info): ignore I/O wait time

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -9,7 +9,7 @@ get_percent()
 {
   case $(uname -s) in
     Linux)
-      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "[C]pu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id, \([0-9.]*\)%* wa.*/\1 \2/" | awk '{print 100 - $1 - $2"%"}')
+      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "[C]pu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id, *\([0-9.]*\)%* wa.*/\1 \2/" | awk '{print 100 - $1 - $2"%"}')
       normalize_percent_len $percent
       ;;
 


### PR DESCRIPTION
`dracula/tmux` reports my CPU usage as ~20% when my computer is mostly idle, whereas other tools, such as `eww` and `waybar`, report it as only ~2%. This is because we are counting I/O wait time as CPU usage. I propose ignoring it and deducting it from the total percentage. After this, the results are coherent across tools.