### PR TITLE
Use typeable word for custom padding instead of zero-width space

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -91,14 +91,17 @@ set -g @dracula-show-empty-plugins false
 
 Set plugin padding
 Whilst the padding is one space per default, can be whatever you want it to be, whether that's whitespace or other characters.
-**If you want to remove any padding, you need to use a zero width space!**
 
 ```bash
 set -g @dracula-left-pad ' ° '
 set -g @dracula-right-pad ' ° '
-# no padding with zero width space
-set -g @dracula-left-pad '​'
-set -g @dracula-right-pad '​'
+```
+
+If you want to remove any padding, you can use `false` as a value.
+
+```bash
+set -g @dracula-left-pad false
+set -g @dracula-right-pad false
 ```
 
 ### Powerline - [up](#table-of-contents)

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -41,6 +41,9 @@ main() {
   left_pad=$(get_tmux_option "@dracula-left-pad" " ")
   right_pad=$(get_tmux_option "@dracula-right-pad" " ")
 
+  if [ "$left_pad" = false ]; then left_pad=""; fi
+  if [ "$right_pad" = false ]; then right_pad=""; fi
+
   narrow_mode=$(get_tmux_option "@dracula-narrow-mode" false)
   if $narrow_mode; then
     IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-narrow-plugins" "compact-alt battery network weather")


### PR DESCRIPTION
This PR resolves #372 .

Although the issue is not always able to reproduce, I believe it is better to use a normal word instead of a specific unicode byte.

It should not affect any previous configs, including the people who were using `U+200B` as their padding.

Thank you!