### PR TITLE
Fix string replacement for home directory in cwd.sh

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -24,8 +24,8 @@ main() {
   fi
 
   # change '/home/user' to '~'
-  cwd="${path/${HOME}/~/}"
-
+  cwd="${path/${HOME}/~}"
+  
   # check max number of subdirs to display. 0 means unlimited
   cwd_max_dirs="$(get_tmux_option "@dracula-cwd-max-dirs" "0")"
 


### PR DESCRIPTION
Remove the single quotes around '~/'. The replacement string in bash parameter expansion is already literal - no quotes needed. With this fix, ```~/tmp will display correctly instead of '~'/tmp.```

Current:
![Screenshot 2026-01-17 at 1 47 07 PM](https://github.com/user-attachments/assets/20ff3be8-7d3a-420b-ac7a-4a34abcc833a)

Fix:
![Screenshot 2026-01-17 at 9 29 46 PM](https://github.com/user-attachments/assets/32a01232-2a92-4425-a92c-f279eda0c5fa)

