### PR TITLE
FIX: weather incorrect param usage

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -314,7 +314,7 @@ main() {
 
     elif [ $plugin = "weather" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
-      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location '$fixed_location' $weather_hide_errors)"
+      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location '"$fixed_location"' $weather_hide_errors)"
 
     elif [ $plugin = "time" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-time-colors" "dark_purple white")

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -28,7 +28,7 @@ function main() {
 
   if (((_now - _last) > INTERVAL)); then
     # Run weather script here
-    "${_current_dir}/weather.sh" "$_show_fahrenheit" "$_show_location" "$_location" "$_hide_errors" >"${DATAFILE}"
+    "${_current_dir}/weather.sh" $_show_fahrenheit $_show_location "$_location" $_hide_errors >"${DATAFILE}"
     printf '%s' "$_now" >"${LAST_EXEC_FILE}"
   fi
 


### PR DESCRIPTION
this close issue #267
	Boolean parameters in tmux.conf were incorrectly treated as strings,
	causing unexpected behavior.

City names with multiple words (e.g., "Los Angeles") were being truncated.