### PR TITLE
🦇 Dracula: use bat emoji for battery

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -204,7 +204,7 @@ This widget provides information about the current charge of the battery, whethe
 Display any icon for the battery you'd like with:
 
 ```bash
-set -g @dracula-battery-label "♥ "
+set -g @dracula-battery-label "🦇 "
 ```
 
 to use nothing but nerdfont icons informing you about the current state, use the following,

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -165,14 +165,6 @@ main()
     bat_label=""
   fi
 
-  if [[ "$bat_label" =~ ^[bB]at$ ]]; then
-    bat_label="🦇"
-  fi
-
-  if [ "$bat_label" == false ]; then
-    bat_label=""
-  fi
-
   # get label for when there is no battery
   no_bat_label=$(get_tmux_option "@dracula-no-battery-label" "AC")
   if [ "$no_bat_label" == false ]; then


### PR DESCRIPTION
Seems to me that it would make sense for the **bat**tery indicator for the Dracula theme to be a **bat**

I implemented it as an option rather than making it the default

<img width="866" height="629" alt="Screenshot from 2026-01-21 16-19-25" src="https://github.com/user-attachments/assets/2370009e-b419-48d6-880a-df23dde6d9eb" />