### PR TITLE
feat: Add option to truncate git branch names

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -412,6 +412,11 @@ Show the current repository name in the status bar
 set -g @dracula-git-show-repo-name true
 ```
 
+Limit the maximum length of git branch names displayed in the status bar. Truncation is disabled by default.
+```bash
+set -g @dracula-git-truncate-length 10
+```
+
 ### gpu-info - [up](#table-of-contents)
 
 These widgets display the current computational, ram, and power usage of installed graphics cards.

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -10,6 +10,7 @@ IFS=' ' read -r -a no_repo_message <<< $(get_tmux_option "@dracula-git-no-repo-m
 IFS=' ' read -r -a no_untracked_files <<< $(get_tmux_option "@dracula-git-no-untracked-files" "false")
 IFS=' ' read -r -a show_remote_status <<< $(get_tmux_option "@dracula-git-show-remote-status" "false")
 show_repo_name="$(get_tmux_option "@dracula-git-show-repo-name" "false")"
+git_truncate_length="$(get_tmux_option "@dracula-git-truncate-length" "")"
 
 # Get added, modified, updated and deleted files from git status
 getChanges()
@@ -143,6 +144,7 @@ getMessage()
 {
     if [ $(checkForGitDir) == "true" ]; then
         branch="$(getBranch)"
+        [ -n "$git_truncate_length" ] && branch="${branch:0:$git_truncate_length}"
         repo_name="$(getRepoName)"
         output=""
 


### PR DESCRIPTION
Added a new option `@dracula-git-truncate-length` to limit the maximum length of git branch names displayed in the status bar. This let truncate long branch names and not take the full length of the tmux window.