### PR TITLE
Fix: Remove blocking sleep in attached_clients.sh to prevent "not ready" status message

### DIFF
--- a/scripts/attached_clients.sh
+++ b/scripts/attached_clients.sh
@@ -16,8 +16,6 @@ count_clients() {
 }
 
 main() {
-  # storing the refresh rate in the variable RATE, default is 5
-  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   clients_count=$(count_clients)
   clients_minimum=$(get_tmux_option "@dracula-clients-minimum" 1)
   if (( $clients_count >= $clients_minimum )); then
@@ -28,7 +26,6 @@ main() {
     fi
     echo "$clients_count $clients_label"
   fi
-  sleep $RATE
 }
 
 # run main driver


### PR DESCRIPTION
Every once tmux startup, a warning message is show as below.

<img width="702" height="66" alt="image" src="https://github.com/user-attachments/assets/0ea09b51-4948-4c20-8cd1-d8f806edcedf" />

## The Problem

The current implementation of main() ends with a sleep $RATE command. Since the tmux status bar executes scripts based on the global status-interval setting, having a sleep command inside the script causes the following issues:

Process Hanging: The script process remains active even after echoing the output, leading tmux to perceive the script as "not ready."

UI Lag: On startup or manual reload, the status bar often fails to render the client count immediately, showing a placeholder error instead.

Redundancy: The refresh frequency is already managed by tmux's internal engine. An internal sleep does not save resources; it only delays the process termination.

## The Solution

By removing sleep $RATE, the "not ready" message is eliminated, and the status bar updates are snappier.

It calculates the client count.

It outputs the formatted string.

It terminates immediately, allowing tmux to capture the output and update the status bar instantly.

## Technical Validation

Resource Usage: Removing the sleep does not increase CPU usage because the execution frequency is controlled externally by the user's `set -g status-interval` or `@dracula-refresh-rate` setting in `.tmux.conf`.

Tmux uses the global `status-interval` setting (default 15s) as its master heartbeat. Every $N$ seconds, Tmux executes all scripts defined in the status-left/right strings. Tmux expects these scripts to be ephemeral: they should calculate data, echo it, and exit immediately.

The current script uses @dracula-refresh-rate to trigger a sleep command at the end of its execution. This effectively turns a "run-and-exit" script into a "long-running" process.

When the script sleeps, the process remains active in the background. If Tmux attempts to refresh the status bar again while the previous script process is still "sleeping," or if Tmux's internal timeout for script execution is reached, it flags the segment as "not ready".