### PR TITLE
Fix: macos version detection

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -37,7 +37,14 @@ get_ssid()
 
       ifname=$(_get_wifi_ifname)
 
-      if (( $(echo "$(sw_vers -productVersion) > 25.0" | bc -l) )); then
+      # string manipulation required to remove the minor version of the macos version (e.g. x.y.z removes .z)
+      # this is required to prevent issues in version detection
+      #
+      # Note: Minor versions do not introduce substantial changes generally only fix bugs
+      macos_version=$(sw_vers -productVersion)
+      macos_version=${macos_version%.*}
+
+      if (( $(echo "$macos_version > 25.0" | bc -l) )); then
         wifi_network=$(networksetup -listpreferredwirelessnetworks "$ifname" | awk 'NR==2 && sub("\t","") { print; exit }')
       else
         wifi_network=$(ipconfig getsummary "$ifname" | awk -F ' SSID : '  '/ SSID : / {print $2}')


### PR DESCRIPTION
Macos 26.4.1 broke the logic in network.sh for the detection of the WiFi network name.

Fix it through string manipulation.