### PR TITLE
feat: detect WiFi SSID in WSL using netsh.exe

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -22,7 +22,11 @@ get_ssid()
   # Check OS
   case $(uname -s) in
     Linux)
-      SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+      if grep -qi microsoft /proc/version 2>/dev/null && command -v netsh.exe &>/dev/null; then
+        SSID=$(netsh.exe wlan show interfaces 2>/dev/null | sed -nr 's/^\s*SSID\s*:\s*(.+)/\1/p' | head -1 | tr -d '\r')
+      else
+        SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+      fi
       if [ -n "$SSID" ]; then
         echo "$wifi_label$SSID"
       else


### PR DESCRIPTION
## Summary

- Add WSL (Windows Subsystem for Linux) WiFi SSID detection in the `network` plugin
- When running in WSL, `iw dev` cannot see WiFi hardware since WSL virtualizes the network interface as ethernet
- This patch detects the WSL environment via `/proc/version` and queries the Windows host's WiFi SSID using `netsh.exe`

## Changes

- `scripts/network.sh`: Added WSL detection in the Linux case of `get_ssid()` — if `/proc/version` contains "microsoft" and `netsh.exe` is available, it uses `netsh.exe wlan show interfaces` to get the SSID. Falls back to the existing `iw dev` logic otherwise.

## Testing

Tested on WSL2 Ubuntu. WiFi SSID is correctly detected and displayed with the wifi label. Non-WSL Linux behavior is unchanged (falls through to `iw dev`).