### PR TITLE
docs(color_theming): add monokai pro

### DIFF
--- a/docs/color_theming/monokai_pro.md
+++ b/docs/color_theming/monokai_pro.md
@@ -1,0 +1,22 @@
+# Drac to Monokai Pro
+
+For a quick setup, set the following options:
+
+```tmux
+# Monokai Pro
+set -g @dracula-colors "
+white='#fcfcfa'
+gray='#403e41'
+dark_gray='#2d2a2e'
+light_purple='#ab9df2'
+dark_purple='#5b595c'
+cyan='#78dce8'
+green='#a9dc76'
+orange='#fc9867'
+red='#ff6188'
+pink='#ff79c6'
+yellow='#ffd866'
+"
+```
+
+Based on [maxpetretta/tmux-monokai-pro](https://github.com/maxpetretta/tmux-monokai-pro)


### PR DESCRIPTION
Saw maxpetretta/tmux-monokai-pro#12 and looks like the original author had not updated the repo in a couple of months, so I thought I would contribute by adding their colors here.