### PR TITLE
scripts/dracula.sh: add 'fill' to message-style for tmux 3.7+

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -171,7 +171,7 @@ main() {
   tmux set-option -g pane-border-style "fg=${gray}"
 
   # message styling
-  tmux set-option -g message-style "bg=${gray},fg=${white}"
+  tmux set-option -g message-style "bg=${gray},fg=${white},fill=${gray}"
 
   # status bar
   tmux set-option -g status-style "bg=${bg_color},fg=${white}"


### PR DESCRIPTION
Add `fill` to Dracula's `message-style` so the message line is fully
covered under tmux 3.7+, which now overlays messages on the status
line instead of replacing it.

## Problem

<img width="332" height="78" alt="image" src="https://github.com/user-attachments/assets/3cae4c1b-a7c9-4101-9a2f-48839f904549" />

On tmux 3.7+, renaming a window (`prefix ,`) shows the adjacent window's name through the prompt:

<img width="339" height="94" alt="image" src="https://github.com/user-attachments/assets/b5b9cbc7-8574-4c82-a873-8f1f3407de51" />

## Repro

1. Open two windows in tmux 3.7+
2. Press `prefix ,` to rename a window
3. Type — observe the adjacent window's name showing to the right of the prompt

## Fix

Add `fill=${gray}` alongside the existing `bg=${gray},fg=${white}`.

`fill=` was added to the style parser in tmux 3.0a, so the change is safe across all currently-supported tmux versions.

## AI assistance

Drafted with [pi](https://github.com/earendil-works/pi-coding-agent) (MiniMax-M3). I reproduced the issue locally, validated the fix on tmux 3.7+, and reviewed the changes.
