### PR TITLE
fix(network): don't show a saved SSID when Wi-Fi is disconnected on macOS

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -41,6 +41,16 @@ get_ssid()
 
       ifname=$(_get_wifi_ifname)
 
+      # Only report a Wi-Fi network when the interface is actually associated. Otherwise the
+      # fallback below can surface a saved/preferred SSID (listpreferredwirelessnetworks) and
+      # show a stale name -- e.g. an old hotspot -- whenever Wi-Fi is off but the machine is
+      # online via Ethernet. Association state stays readable even though the SSID itself is
+      # gated behind Location Services on macOS 15+.
+      if [[ "$(ifconfig "$ifname" 2>/dev/null | awk '/status:/ {print $2}')" != "active" ]]; then
+        echo "$ethernet_label"
+        return
+      fi
+
       # string manipulation required to remove the minor version of the macos version (e.g. x.y.z removes .z)
       # this is required to prevent issues in version detection
       #


### PR DESCRIPTION
## Problem

On macOS, `scripts/network.sh` derives the candidate Wi-Fi name (`wifi_network`) from:

```bash
networksetup -listpreferredwirelessnetworks "$ifname" | awk 'NR==2 && sub("\t","") { print; exit }'
```

`listpreferredwirelessnetworks` lists **saved / preferred** networks, not the current association. It is used as the fallback when `getairportnetwork` reports *"You are not associated with an AirPort network."*

So when **Wi-Fi is off but the machine is online via Ethernet**, the host ping passes, `getairportnetwork` correctly returns "not associated", and the module falls back to the first **saved** network — showing a stale SSID (e.g. an old phone hotspot) the machine is not connected to.

Closes #396.

## Fix

Gate the Darwin Wi-Fi branch on the interface actually being associated, before consulting any SSID source:

```bash
if [[ "$(ifconfig "$ifname" 2>/dev/null | awk '/status:/ {print $2}')" != "active" ]]; then
  echo "$ethernet_label"
  return
fi
```

`ifconfig "$ifname"` reports `status: active` only when the interface is associated to an AP (`inactive` when Wi-Fi is off or unassociated). This signal stays readable even though the SSID itself is gated behind Location Services on macOS 15+.

The existing #370 SSID resolution (`getairportnetwork` + the `listpreferredwirelessnetworks`/`ipconfig` fallback) is **left untouched**, so there is no behavior change for users currently on Wi-Fi — only the not-associated case stops surfacing a saved name.

## Testing

macOS 26.3, Wi-Fi off + online via Ethernet:

- Before: module shows the first saved network (e.g. an old hotspot name).
- After: module shows `Ethernet`.

`bash -n scripts/network.sh` passes.
