### PR TITLE
feat: enable color customisation of individual custom plugins

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -976,3 +976,13 @@ set -g @dracula-weather-hide-errors true
 
 For testing/ running custom plugins, put the bash script into the scripts directory of dracula/tmux plugin.
 Additionally, in the `@dracula-plugins` option, add the script as `custom:name-of-script.sh`.
+
+Each custom plugin can have its own colors, just like a packaged plugin, by setting
+`@dracula-custom-<name-of-script>-colors "bg fg"` (the `custom-` prefix avoids clashing with a
+packaged plugin's own `@dracula-<name-of-script>-colors` option, should one exist). If unset, it
+falls back to `@dracula-custom-plugin-colors "bg fg"`, and then to dracula defaults.
+
+```bash
+set -g @dracula-plugins "custom:docker.sh"
+set -g @dracula-custom-docker-colors "blue dark_gray"
+```

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -196,7 +196,13 @@ main() {
     if case $plugin in custom:*) true;; *) false;; esac; then
       script=${plugin#"custom:"}
       if [[ -x "${current_dir}/${script}" ]]; then
-        IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-custom-plugin-colors" "cyan dark_gray")
+        custom_plugin_name=$(basename "${script}")
+        custom_plugin_name=${custom_plugin_name%.sh}
+        custom_plugin_colors=$(get_tmux_option "@dracula-custom-${custom_plugin_name}-colors" "")
+        if [ -z "$custom_plugin_colors" ]; then
+          custom_plugin_colors=$(get_tmux_option "@dracula-custom-plugin-colors" "cyan dark_gray")
+        fi
+        IFS=' ' read -r -a colors <<<"$custom_plugin_colors"
         script="#($current_dir/${script})"
       else
         colors[0]="red"


### PR DESCRIPTION
Allow configuration of custom plugin colors as if they were dracula plugins.

For all `custom:<plugin-name>` :
- script name is parsed to remove `.sh`
- `@dracula-custom-<plugin-name>-colors` is checked
- else it fallbacks on `@dracula-custom-plugin-colors` or dracula defaults (`"cyan dark_dray"`)
- the colors is then applied as before

Assisted-by: Claude Sonnet 5