### PR TITLE
feat: allow configuring network-vpn interface (default tun0)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -718,6 +718,11 @@ Set verbose to true in order to see the VPNs IP or name of Tailscale exit node.
 set -g @dracula-network-vpn-verbose true
 ```
 
+Set the interface to check for VPN connection (default to `tun0`)
+```
+set -g @dracula-network-vpn-interface proton0
+```
+
 Set the widgets label like so:
 ```bash
 set -g @dracula-network-vpn-label "󰌘 "

--- a/scripts/network_vpn.sh
+++ b/scripts/network_vpn.sh
@@ -13,8 +13,10 @@ vpn_function() {
 
     verbose=$(get_tmux_option "@dracula-network-vpn-verbose" false)
 
-    # Show IP of tun0 if connected
-    vpn=$(ip -o -4 addr show dev tun0 | awk '{print $4}' | cut -d/ -f1)
+    # Show IP of the VPN interface if connected (defaults to tun0, override
+    # with e.g. `set -g @dracula-network-vpn-interface "proton0"` for Proton VPN)
+    vpn_interface=$(get_tmux_option "@dracula-network-vpn-interface" "tun0")
+    vpn=$(ip -o -4 addr show dev "$vpn_interface" 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
 
     which -s tailscale > /dev/null
     tailscale_installed=$?


### PR DESCRIPTION
Allow configuring the network interface that `network-vpn` plugin checks to display vpn status.

The option is `@dracula-network-vpn-interface` (defaults to `tun0`, which is hard coded today)