### PR TITLE
feat: send session_name to scripts that need it 

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -5,18 +5,16 @@ source "$current_dir/utils.sh"
 
 # return current working directory of tmux pane
 getPaneDir() {
-  nextone="false"
-  ret=""
-  for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}"); do
-    [ "$i" == "1" ] && nextone="true" && continue
-    [ "$i" == "0" ] && nextone="false"
-    [ "$nextone" == "true" ] && ret+="$i "
-  done
-  echo "${ret%?}"
+  local session="$1"
+  if [ -n "$session" ]; then
+    tmux list-panes -t "$session" -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
+  else
+    tmux list-panes -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
+  fi
 }
 
 main() {
-  path="$(getPaneDir)"
+  path="$(getPaneDir "$1")"
 
   if [[ "$path" == "$HOME" ]]; then
     echo "~"
@@ -50,4 +48,4 @@ main() {
 }
 
 #run main driver program
-main
+main "$@"

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -197,7 +197,7 @@ main() {
       script=${plugin#"custom:"}
       if [[ -x "${current_dir}/${script}" ]]; then
         IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-custom-plugin-colors" "cyan dark_gray")
-        script="#($current_dir/${script})"
+        script="#($current_dir/${script} #{session_name})"
       else
         colors[0]="red"
         colors[1]="dark_gray"
@@ -212,22 +212,22 @@ main() {
     elif [ $plugin = "cwd" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/cwd.sh)"
+      script="#($current_dir/cwd.sh #{session_name})"
 
     elif [ $plugin = "fossil" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-fossil-colors" "green dark_gray")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/fossil.sh)"
+      script="#($current_dir/fossil.sh #{session_name})"
 
     elif [ $plugin = "git" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-git-colors" "green dark_gray")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/git.sh)"
+      script="#($current_dir/git.sh #{session_name})"
 
     elif [ $plugin = "hg" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-hg-colors" "green dark_gray")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/hg.sh)"
+      script="#($current_dir/hg.sh #{session_name})"
 
     elif [ $plugin = "battery" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")

--- a/scripts/fossil.sh
+++ b/scripts/fossil.sh
@@ -48,20 +48,14 @@ for i in $(cd $path; fossil changes --differ|cut -f1 -d' ')
 }
 
 
-# getting the #{pane_current_path} from dracula.sh is no longer possible
 getPaneDir()
 {
- nextone="false"
- for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
- do
-    if [ "$nextone" == "true" ]; then
-       echo $i
-       return
-    fi 
-    if [ "$i" == "1" ]; then
-        nextone="true"
+    local session="$1"
+    if [ -n "$session" ]; then
+        tmux list-panes -t "$session" -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
+    else
+        tmux list-panes -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
     fi
-  done
 }
 
 
@@ -169,10 +163,10 @@ getMessage()
 }
 
 main()
-{  
-    path=$(getPaneDir)
+{
+    path=$(getPaneDir "$1")
     getMessage
 }
 
 #run main driver program
-main 
+main "$@"

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -50,20 +50,14 @@ for i in $(git -C $path --no-optional-locks status -s)
 }
 
 
-# getting the #{pane_current_path} from dracula.sh is no longer possible
 getPaneDir()
 {
- nextone="false"
- for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
- do
-    if [ "$nextone" == "true" ]; then
-       echo $i
-       return
-    fi 
-    if [ "$i" == "1" ]; then
-        nextone="true"
+    local session="$1"
+    if [ -n "$session" ]; then
+        tmux list-panes -t "$session" -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
+    else
+        tmux list-panes -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
     fi
-  done
 }
 
 
@@ -182,10 +176,10 @@ getMessage()
 }
 
 main()
-{  
-    path=$(getPaneDir)
+{
+    path=$(getPaneDir "$1")
     getMessage
 }
 
 #run main driver program
-main 
+main "$@"

--- a/scripts/hg.sh
+++ b/scripts/hg.sh
@@ -51,20 +51,14 @@ for i in $(hg -R $path status -admru)
 }
 
 
-# getting the #{pane_current_path} from dracula.sh is no longer possible
 getPaneDir()
 {
- nextone="false"
- for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
- do
-    if [ "$nextone" == "true" ]; then
-       echo $i
-       return
+    local session="$1"
+    if [ -n "$session" ]; then
+        tmux list-panes -t "$session" -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
+    else
+        tmux list-panes -f '#{pane_active}' -F "#{pane_current_path}" 2>/dev/null
     fi
-    if [ "$i" == "1" ]; then
-        nextone="true"
-    fi
-  done
 }
 
 
@@ -155,9 +149,9 @@ getMessage()
 
 main()
 {
-    path=$(getPaneDir)
+    path=$(getPaneDir "$1")
     getMessage
 }
 
 #run main driver program
-main
+main "$@"


### PR DESCRIPTION
`git.sh`, `cwd.sh`, etc, are trying to display data about the current active pane. However, with how it is handled today, having two different sessions live with two different panes would show erroneous data in one of them since the scrips cannot know in which session they are running.
It can be fixed by using `#{session_name}` to find the active pane in the right session.

Assisted-by: Claude Sonnet 5